### PR TITLE
Fixed: section-wizard - Section Wizard Plugin not working on DX8 theme @7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.joget.plugin</groupId>
     <artifactId>section-wizard</artifactId>
     <packaging>bundle</packaging>
-    <version>7.0.7</version>
+    <version>7.0.8</version>
     <name>section-wizard</name>
     <url>http://www.joget.org</url>
     <build>

--- a/src/main/java/org/joget/plugin/SectionWizard.java
+++ b/src/main/java/org/joget/plugin/SectionWizard.java
@@ -23,7 +23,7 @@ public class SectionWizard extends Element implements FormBuilderPaletteElement,
 
     @Override
     public String getVersion() {
-        return "7.0.7";
+        return "7.0.8";
     }
 
     @Override

--- a/src/main/java/org/joget/plugin/SectionWizardChild.java
+++ b/src/main/java/org/joget/plugin/SectionWizardChild.java
@@ -30,7 +30,7 @@ public class SectionWizardChild extends Section implements PluginWebSupport {
     
     @Override
     public String getVersion() {
-        return "7.0.7";
+        return "7.0.8";
     }
     
     @Override

--- a/src/main/resources/templates/sectionWizard.ftl
+++ b/src/main/resources/templates/sectionWizard.ftl
@@ -12,7 +12,7 @@
             .wizard > .easyWizardSteps li.current {color:#000; font-weight: bold;}
             .wizard > .easyWizardSteps li.error {color:red;}
             .wizard > .easyWizardWrapper > .step.active {visibility: unset !important}
-            .wizard > .easyWizardWrapper > .step{visibility: hidden;display:block; padding:0px !important; border:0px !important; clear: right !important; margin:0 !important; margin-top:0px !important; box-shadow:none !important; }
+            .wizard > .easyWizardWrapper > .step{visibility: hidden;display:block !important; padding:0px !important; border:0px !important; clear: right !important; margin:0 !important; margin-top:0px !important; box-shadow:none !important; }
             .wizard > .easyWizardWrapperContainer > .easyWizardWrapper > .step_wrapper > .step{display:block !important; padding:0px !important;  margin:0 !important; margin-top:0px !important; box-shadow:none !important; clear: right !important; border: 0px !important;}
             .wizard > .easyWizardButtons {overflow:hidden;padding:10px;}
             .wizard > .easyWizardButtons button, .easyWizardButtons .submit {cursor:pointer}


### PR DESCRIPTION
Fixed an issue where some sections are not showing due to `.form-section-empty { display: none !important; }` from `wflow-consoleweb/webapp/css/form8.css` overriding the styles of the plugin.

Changes:
- Added `!important` to the `.wizard > .easyWizardWrapper > .step { display: block; }` CSS to ensure that the sections will be displayed.